### PR TITLE
RSDK-428: Pull RSDK from Artifactory

### DIFF
--- a/ios/ios-sample-app.xcodeproj/project.pbxproj
+++ b/ios/ios-sample-app.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		51F711282DA5AF4900EC503D /* RSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 51F711272DA5AF4900EC503D /* RSDK */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		519F04E12CB0917300F6790A /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -49,6 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				51F711282DA5AF4900EC503D /* RSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,6 +105,7 @@
 			);
 			name = "ios-sample-app";
 			packageProductDependencies = (
+				51F711272DA5AF4900EC503D /* RSDK */,
 			);
 			productName = "ios-sample-app";
 			productReference = 5199F32C2CA475FC00AF77CC /* ios-sample-app.app */;
@@ -129,6 +135,9 @@
 			);
 			mainGroup = 5199F3232CA475FC00AF77CC;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				51F711262DA5AF4900EC503D /* XCRemoteSwiftPackageReference "gotenna-rsdk-spm" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5199F32D2CA475FC00AF77CC /* Products */;
 			projectDirPath = "";
@@ -365,6 +374,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		51F711262DA5AF4900EC503D /* XCRemoteSwiftPackageReference "gotenna-rsdk-spm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gotenna/gotenna-rsdk-spm";
+			requirement = {
+				kind = exactVersion;
+				version = 3.1.13;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		51F711272DA5AF4900EC503D /* RSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51F711262DA5AF4900EC503D /* XCRemoteSwiftPackageReference "gotenna-rsdk-spm" */;
+			productName = RSDK;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 5199F3242CA475FC00AF77CC /* Project object */;
 }

--- a/ios/ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "9b43e06b27e4d5f5d40a6f1a87bb482121e7f8e10bdc036f073fda6af2c7079f",
+  "pins" : [
+    {
+      "identity" : "gotenna-rsdk-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gotenna/gotenna-rsdk-spm",
+      "state" : {
+        "revision" : "fc3715af073795aa91121f2f2b3f507cf9e3b6a4",
+        "version" : "3.1.13"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
You'll need to make sure you have your Artifactory/JFrog credentials in Keychain:

![keychain](https://github.com/user-attachments/assets/51d6f5d8-625a-4f7d-9141-8517a8db42f3)

I also created this repo and set its initial version to v3.1.13 after publishing that version for iOS:
https://github.com/gotenna/gotenna-rsdk-spm

If we want to update the version for the sample app in the future, you can modify this version in Xcode (which should match a release version from the above repo):
![version](https://github.com/user-attachments/assets/57a37a73-bb81-4b62-85ab-192ae751d6f3)

You might have to resolve packages again in Xcode after changing the version:
![resolve](https://github.com/user-attachments/assets/1a4f8c77-c34d-4f22-ae25-568beb1cf9b8)
