### PR TITLE
RSDK-505: Minimize logging and add getters

### DIFF
--- a/linux-jvm/gradle/libs.versions.toml
+++ b/linux-jvm/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+sample-app = "0.0.2"
 radio-sdk = "3.2.29"
 agp = "8.1.4"
 kotlin = "2.0.0"

--- a/linux-jvm/spring-boot/build.gradle.kts
+++ b/linux-jvm/spring-boot/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.gotenna.sdk-examples.spring-boot"
-version = "0.0.1-SNAPSHOT"
+version = libs.versions.sample.app.get()
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -59,4 +59,10 @@ dependencyManagement {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+    archiveBaseName.set("jvm-sample-cli")
+    archiveClassifier.set("")
+    archiveVersion.set(libs.versions.sample.app.get())
 }

--- a/linux-jvm/spring-boot/src/main/kotlin/com/gotenna/spring/sample/RadioLogSuppressor.kt
+++ b/linux-jvm/spring-boot/src/main/kotlin/com/gotenna/spring/sample/RadioLogSuppressor.kt
@@ -1,0 +1,21 @@
+package com.gotenna.spring.sample
+
+import java.io.OutputStream
+
+class RadioLogSuppressor(private val source: OutputStream): OutputStream() {
+
+    override fun write(byte: Int) {
+        source.write(byte)
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int) {
+        val message = String(bytes, offset, length)
+        if (shouldBlock(message)) return
+        source.write(bytes, offset, length)
+    }
+
+    private fun shouldBlock(message: String): Boolean {
+        return message.contains("Device - ")
+    }
+
+}


### PR DESCRIPTION
Suppresses most of the radio SDK chatter, focusing on the output of commands and messages
Adds commands to get frequencies, and power/bandwidth from radio
Renames the output jar to "jvm-sample-cli-<version>"