### PR TITLE
RSDK-791 - Update linux sample to Radio SDK 3.4.15

### DIFF
--- a/linux-jvm/gradle/libs.versions.toml
+++ b/linux-jvm/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 sample-app = "0.0.2"
-radio-sdk = "3.3.19"
+radio-sdk = "3.4.15"
 agp = "8.1.4"
 kotlin = "2.0.0"
 kotlinx-serialization = "1.7.0"

--- a/linux-jvm/spring-boot/src/main/kotlin/com/gotenna/spring/sample/JavaRadioCli.java
+++ b/linux-jvm/spring-boot/src/main/kotlin/com/gotenna/spring/sample/JavaRadioCli.java
@@ -159,7 +159,8 @@ public class JavaRadioCli {
                                 "senderUUID",
                                 "senderCallsign",
                                 null,
-                                "uuid"
+                                "uuid",
+                                null
                         ),
                         GripResult.Unknown.INSTANCE,
                         null,


### PR DESCRIPTION
## Summary
- Bump `radio-sdk` from `3.3.19` to `3.4.15` in `linux-jvm/gradle/libs.versions.toml`.
- Add the new `sendMeshAddressResolution` argument to the `GotennaHeaderWrapper` constructor call in `JavaRadioCli.java`. Kotlin call sites use the default value; Java callers must pass it explicitly.

Jira: https://gotenna.atlassian.net/browse/RSDK-791

## Test plan
- [x] `gradle build -x test` passes on `linux-jvm` against Radio SDK 3.4.15