### PR TITLE
RSDK-792 - Update android sample to Radio SDK 3.4.15

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ appcompat = "1.7.0"
 composeBom = "2025.04.00"
 constraintlayout = "2.2.1"
 fragment = "1.8.6"
-gotennaRadioSdk = "3.3.19"
+gotennaRadioSdk = "3.4.15"
 kotlin = "2.0.21"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Bump `gotennaRadioSdk` from `3.3.19` to `3.4.15` in `android/gradle/libs.versions.toml`.
- No call-site changes needed: the new optional `sendMeshAddressResolution` parameter on `GotennaHeaderWrapper` falls back to its default value because all sample constructions use named arguments.

Jira: https://gotenna.atlassian.net/browse/RSDK-792

## Test plan
- [x] `gradle :app:assembleDebug` passes on `android` against Radio SDK 3.4.15