### PR TITLE
RSDK-793 - Update iOS sample to Radio SDK 3.4.15

### DIFF
--- a/ios/ios-sample-app.xcodeproj/project.pbxproj
+++ b/ios/ios-sample-app.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 			repositoryURL = "https://github.com/gotenna/gotenna-rsdk-spm";
 			requirement = {
 				kind = exactVersion;
-				version = 3.3.19;
+				version = 3.4.15;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gotenna/gotenna-rsdk-spm",
       "state" : {
-        "revision" : "1f394757fdd67a6f32ec2c6f38141c95f1c7a055",
-        "version" : "3.3.19"
+        "revision" : "3980e9e861c88bb04498def723097abed803f685",
+        "version" : "3.4.15"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Bump the `gotenna-rsdk-spm` SPM dependency from `3.3.19` to `3.4.15` in `project.pbxproj` and `Package.resolved`.
- No source changes needed: the Swift call sites for `GotennaHeaderWrapper` already pass `sendMeshAddressResolution` (added by an earlier "Fix compiler issues" commit), so they match the 3.4.15 generated interface.

The `v3.4.15` SPM tag was published out-of-band on `gotenna/gotenna-rsdk-spm` (release: https://github.com/gotenna/gotenna-rsdk-spm/releases/tag/v3.4.15) — `main` of that repo still points at `v3.4.22`.

Jira: https://gotenna.atlassian.net/browse/RSDK-793

## Test plan
- [x] `xcodebuild -resolvePackageDependencies` resolves RSDK at 3.4.15
- [x] `swiftc -typecheck` on all sample Swift files against the 3.4.15 XCFramework passes with no errors (only pre-existing string-interpolation warnings)
- [x] Full `xcodebuild build` on `generic/platform=iOS Simulator` with `ARCHS=arm64` produces `ios-sample-app.app` against the 3.4.15 XCFramework (arm64-only because the RSDK XCFramework does not ship an x86_64 simulator slice)