### PR TITLE
RSDK-794 - Update linux sample to Radio SDK 3.4.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RSDK - Radio SDK
-[![Version](https://img.shields.io/badge/Version-3.4.15-blue)](https://github.com/gotenna/rsdk-samples/)
+[![Version](https://img.shields.io/badge/Version-3.4.22-blue)](https://github.com/gotenna/rsdk-samples/)
 [![Test Coverage](https://img.shields.io/badge/Coverage-86.55%25-brightgreen)](https://ci.example.com/testcoverage)
 [![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen)](https://ci.example.com/buildstatus)
 

--- a/linux-jvm/gradle/libs.versions.toml
+++ b/linux-jvm/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 sample-app = "0.0.2"
-radio-sdk = "3.4.15"
+radio-sdk = "3.4.22"
 agp = "8.1.4"
 kotlin = "2.0.0"
 kotlinx-serialization = "1.7.0"


### PR DESCRIPTION
## Summary
- Stacked on top of #35 (RSDK-791, 3.3.19 → 3.4.15). Bumps `radio-sdk` from `3.4.15` to `3.4.22`.
- No source changes needed.

Jira: https://gotenna.atlassian.net/browse/RSDK-794

## Test plan
- [x] `gradle build -x test` passes on `linux-jvm` against Radio SDK 3.4.22