### PR TITLE
RSDK-795 - Update android sample to Radio SDK 3.4.22

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ appcompat = "1.7.0"
 composeBom = "2025.04.00"
 constraintlayout = "2.2.1"
 fragment = "1.8.6"
-gotennaRadioSdk = "3.4.15"
+gotennaRadioSdk = "3.4.22"
 kotlin = "2.0.21"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Stacked on top of #36 (RSDK-792, 3.3.19 → 3.4.15). Bumps `gotennaRadioSdk` from `3.4.15` to `3.4.22`.
- No source changes needed.

Jira: https://gotenna.atlassian.net/browse/RSDK-795

## Test plan
- [x] `gradle :app:assembleDebug` passes on `android` against Radio SDK 3.4.22