### PR TITLE
RSDK-796 - Update iOS sample to Radio SDK 3.4.22

### DIFF
--- a/ios/ios-sample-app.xcodeproj/project.pbxproj
+++ b/ios/ios-sample-app.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 			repositoryURL = "https://github.com/gotenna/gotenna-rsdk-spm";
 			requirement = {
 				kind = exactVersion;
-				version = 3.4.15;
+				version = 3.4.22;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gotenna/gotenna-rsdk-spm",
       "state" : {
-        "revision" : "3980e9e861c88bb04498def723097abed803f685",
-        "version" : "3.4.15"
+        "revision" : "55ac93c190d7854be293daf494c07d68ebf2a07c",
+        "version" : "3.4.22"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Stacked on top of #37 (RSDK-793, 3.3.19 → 3.4.15). Bumps the `gotenna-rsdk-spm` SPM dependency from `3.4.15` to `3.4.22`.
- No source changes needed.

Jira: https://gotenna.atlassian.net/browse/RSDK-796

## Test plan
- [x] `xcodebuild -resolvePackageDependencies` resolves RSDK at 3.4.22
- [x] `xcodebuild build -destination "generic/platform=iOS Simulator" ARCHS=arm64` produces `ios-sample-app.app` against the 3.4.22 XCFramework (arm64-only because the RSDK XCFramework does not ship an x86_64 simulator slice)