### PR TITLE
RSDK-812 - Pin slackapi/slack-github-action to commit SHA

### DIFF
--- a/.github/workflows/slack-notification-pull-request-approved.yml
+++ b/.github/workflows/slack-notification-pull-request-approved.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Message
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/slack-notification-pull-request-merged.yml
+++ b/.github/workflows/slack-notification-pull-request-merged.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Message
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/slack-notification-pull-request-opened.yml
+++ b/.github/workflows/slack-notification-pull-request-opened.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Message
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Summary
- Pin `slackapi/slack-github-action@v1.27.0` to its commit SHA `37ebaef184d7626c5f204ab8d3baff4262dd30f0` in all three Slack-notification workflows.
- Mitigates the supply-chain risk Aikido flagged in [RSDK-812](https://gotenna.atlassian.net/browse/RSDK-812): an unpinned third-party Action could be compromised at the tag level.

## Test plan
- [x] Open this PR triggers `slack-notification-pull-request-opened` successfully.
- [x] Approving this PR triggers `slack-notification-pull-request-approved` successfully.
- [x] Merging this PR triggers `slack-notification-pull-request-merged` successfully.

[RSDK-812]: https://gotenna.atlassian.net/browse/RSDK-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ